### PR TITLE
Add geofence monitor

### DIFF
--- a/GeofenceMe.xcodeproj/project.pbxproj
+++ b/GeofenceMe.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		22879EF526D7815400682651 /* GeofenceCheckService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22879EF426D7815400682651 /* GeofenceCheckService.swift */; };
 		22879EF726D7891600682651 /* WifiDetectorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22879EF626D7891600682651 /* WifiDetectorService.swift */; };
 		2297F27026DF2CA600BF241C /* GeofenceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2297F26F26DF2CA600BF241C /* GeofenceMonitor.swift */; };
+		2297F27A26DF72F200BF241C /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2297F27926DF72F200BF241C /* NotificationService.swift */; };
 		E3E4A1BA26D9E3FD00A2D818 /* GeofenceViewPresenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E4A1B926D9E3FD00A2D818 /* GeofenceViewPresenterDelegate.swift */; };
 		E3E4A1BC26DA488B00A2D818 /* GeofenceCheckServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E4A1BB26DA488B00A2D818 /* GeofenceCheckServiceTests.swift */; };
 		E3E4A1BE26DA521500A2D818 /* GeofenceViewPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E4A1BD26DA521500A2D818 /* GeofenceViewPresenterTests.swift */; };
@@ -97,6 +98,7 @@
 		22879EF426D7815400682651 /* GeofenceCheckService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceCheckService.swift; sourceTree = "<group>"; };
 		22879EF626D7891600682651 /* WifiDetectorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WifiDetectorService.swift; sourceTree = "<group>"; };
 		2297F26F26DF2CA600BF241C /* GeofenceMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceMonitor.swift; sourceTree = "<group>"; };
+		2297F27926DF72F200BF241C /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		E3E4A1B926D9E3FD00A2D818 /* GeofenceViewPresenterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceViewPresenterDelegate.swift; sourceTree = "<group>"; };
 		E3E4A1BB26DA488B00A2D818 /* GeofenceCheckServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceCheckServiceTests.swift; sourceTree = "<group>"; };
 		E3E4A1BD26DA521500A2D818 /* GeofenceViewPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceViewPresenterTests.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 		22879E8E26D3CB1600682651 /* GeofenceMe */ = {
 			isa = PBXGroup;
 			children = (
+				2297F27826DF72D700BF241C /* NotificationService */,
 				22879EF826D7891E00682651 /* WifiDetector */,
 				22879EEF26D634FA00682651 /* GeofenceView */,
 				22879EDC26D619B300682651 /* GeofenceService */,
@@ -260,6 +263,14 @@
 				22879EF626D7891600682651 /* WifiDetectorService.swift */,
 			);
 			path = WifiDetector;
+			sourceTree = "<group>";
+		};
+		2297F27826DF72D700BF241C /* NotificationService */ = {
+			isa = PBXGroup;
+			children = (
+				2297F27926DF72F200BF241C /* NotificationService.swift */,
+			);
+			path = NotificationService;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -413,6 +424,7 @@
 				E3E4A1BA26D9E3FD00A2D818 /* GeofenceViewPresenterDelegate.swift in Sources */,
 				22879ED926D6124D00682651 /* AddGeofenceViewPresenter.swift in Sources */,
 				22879EC626D4AFC800682651 /* LocationServiceProviding.swift in Sources */,
+				2297F27A26DF72F200BF241C /* NotificationService.swift in Sources */,
 				22879EE026D61A2800682651 /* GeofenceStorageProviding.swift in Sources */,
 				22879EF726D7891600682651 /* WifiDetectorService.swift in Sources */,
 				22879E9226D3CB1600682651 /* SceneDelegate.swift in Sources */,

--- a/GeofenceMe.xcodeproj/project.pbxproj
+++ b/GeofenceMe.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		22879EF326D635A100682651 /* GeofenceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22879EF226D635A100682651 /* GeofenceViewModel.swift */; };
 		22879EF526D7815400682651 /* GeofenceCheckService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22879EF426D7815400682651 /* GeofenceCheckService.swift */; };
 		22879EF726D7891600682651 /* WifiDetectorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22879EF626D7891600682651 /* WifiDetectorService.swift */; };
+		2297F27026DF2CA600BF241C /* GeofenceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2297F26F26DF2CA600BF241C /* GeofenceMonitor.swift */; };
 		E3E4A1BA26D9E3FD00A2D818 /* GeofenceViewPresenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E4A1B926D9E3FD00A2D818 /* GeofenceViewPresenterDelegate.swift */; };
 		E3E4A1BC26DA488B00A2D818 /* GeofenceCheckServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E4A1BB26DA488B00A2D818 /* GeofenceCheckServiceTests.swift */; };
 		E3E4A1BE26DA521500A2D818 /* GeofenceViewPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E4A1BD26DA521500A2D818 /* GeofenceViewPresenterTests.swift */; };
@@ -95,6 +96,7 @@
 		22879EF226D635A100682651 /* GeofenceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceViewModel.swift; sourceTree = "<group>"; };
 		22879EF426D7815400682651 /* GeofenceCheckService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceCheckService.swift; sourceTree = "<group>"; };
 		22879EF626D7891600682651 /* WifiDetectorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WifiDetectorService.swift; sourceTree = "<group>"; };
+		2297F26F26DF2CA600BF241C /* GeofenceMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceMonitor.swift; sourceTree = "<group>"; };
 		E3E4A1B926D9E3FD00A2D818 /* GeofenceViewPresenterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceViewPresenterDelegate.swift; sourceTree = "<group>"; };
 		E3E4A1BB26DA488B00A2D818 /* GeofenceCheckServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceCheckServiceTests.swift; sourceTree = "<group>"; };
 		E3E4A1BD26DA521500A2D818 /* GeofenceViewPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceViewPresenterTests.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				22879EDF26D61A2800682651 /* GeofenceStorageProviding.swift */,
 				22879EE126D61A4F00682651 /* GeofenceInfo.swift */,
 				22879EF426D7815400682651 /* GeofenceCheckService.swift */,
+				2297F26F26DF2CA600BF241C /* GeofenceMonitor.swift */,
 			);
 			path = GeofenceService;
 			sourceTree = "<group>";
@@ -394,6 +397,7 @@
 				22879EF326D635A100682651 /* GeofenceViewModel.swift in Sources */,
 				22879EF526D7815400682651 /* GeofenceCheckService.swift in Sources */,
 				22879EE226D61A4F00682651 /* GeofenceInfo.swift in Sources */,
+				2297F27026DF2CA600BF241C /* GeofenceMonitor.swift in Sources */,
 				22879EDB26D612F000682651 /* AddGeofenceViewPresenterDelegate.swift in Sources */,
 				22879EF126D6351400682651 /* GeofenceViewPresenter.swift in Sources */,
 				22879EED26D634F400682651 /* GeofenceViewController.swift in Sources */,

--- a/GeofenceMe/AddGeofence/AddGeofenceViewPresenter.swift
+++ b/GeofenceMe/AddGeofence/AddGeofenceViewPresenter.swift
@@ -50,7 +50,6 @@ class AddGeofenceViewPresenter {
     }
     
     func stopLocationUpdate() {
-        
         locationService.stopLocationDetection()
     }
     
@@ -61,7 +60,7 @@ class AddGeofenceViewPresenter {
     func saveGeofence() {
         let geofence = GeofenceInfo(latitude: latitude, longitude: longitude, radius: Int(currentFenceRange))
         geofenceService.saveGeofence(geofence)
-        
+        locationService.startMonitoring(geofence: geofence)
     }
 }
 

--- a/GeofenceMe/AppDelegate.swift
+++ b/GeofenceMe/AppDelegate.swift
@@ -6,12 +6,18 @@
 //
 
 import UIKit
+import CoreLocation
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    private var geofenceMonitor: GeofenceMonitor?
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        
+        geofenceMonitor = GeofenceMonitor(locationManager: CLLocationManager())
+        geofenceMonitor?.start()
+        
         return true
     }
 

--- a/GeofenceMe/GeofenceService/GeofenceMonitor.swift
+++ b/GeofenceMe/GeofenceService/GeofenceMonitor.swift
@@ -1,0 +1,37 @@
+//
+//  GeofenceMonitor.swift
+//  GeofenceMe
+//
+//  Created by Abd Sani Abd Jalal on 01/09/2021.
+//
+
+import Foundation
+import CoreLocation
+
+class GeofenceMonitor: NSObject {
+    private var locationManager: CLLocationManager
+    
+    init(locationManager: CLLocationManager) {
+        self.locationManager = locationManager
+        super.init()
+    }
+    
+    func start() {
+        locationManager.delegate = self
+    }
+    
+    func stop() {
+        locationManager.delegate = nil
+    }
+}
+
+extension GeofenceMonitor: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+    }
+}

--- a/GeofenceMe/GeofenceService/GeofenceMonitor.swift
+++ b/GeofenceMe/GeofenceService/GeofenceMonitor.swift
@@ -10,13 +10,16 @@ import CoreLocation
 
 class GeofenceMonitor: NSObject {
     private var locationManager: CLLocationManager
+    private var notificationService: NotificationService
     
-    init(locationManager: CLLocationManager) {
+    init(locationManager: CLLocationManager, notificationService: NotificationService = NotificationService()) {
         self.locationManager = locationManager
+        self.notificationService = notificationService
         super.init()
     }
     
     func start() {
+        notificationService.clearNotifications()
         locationManager.delegate = self
     }
     
@@ -30,8 +33,12 @@ extension GeofenceMonitor: CLLocationManagerDelegate {
     }
     
     func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+        print("Did enter region")
+        notificationService.sendLocalNotification(text: "Entered Region!")
     }
     
     func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+        print("Did exit region")
+        notificationService.sendLocalNotification(text: "Exit Region!")
     }
 }

--- a/GeofenceMe/GeofenceView/GeofenceViewController.swift
+++ b/GeofenceMe/GeofenceView/GeofenceViewController.swift
@@ -33,6 +33,7 @@ class GeofenceViewController: UIViewController {
         super.viewDidLoad()
         mapView.delegate = self
         updateView()
+        presenter.getNotificationPermission()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/GeofenceMe/GeofenceView/GeofenceViewPresenter.swift
+++ b/GeofenceMe/GeofenceView/GeofenceViewPresenter.swift
@@ -15,6 +15,7 @@ class GeofenceViewPresenter {
     private var geofenceService: GeofenceStorageProviding
     private var wifiService: WifiDetectorService
     private var locationService: LocationServiceProviding
+    private var notificationService: NotificationService = NotificationService()
     
     init(viewModel: GeofenceViewModel = GeofenceViewModel(),
          geofenceService: GeofenceStorageProviding = GeofenceStorageService(),
@@ -33,6 +34,10 @@ class GeofenceViewPresenter {
         self.locationService.delegate = self
         startLocationDetection()
         retrieveGeofenceInfo()
+    }
+    
+    func getNotificationPermission() {
+        notificationService.requestPermission()
     }
     
     func startLocationDetection() {

--- a/GeofenceMe/LocationService/LocationServiceProvider.swift
+++ b/GeofenceMe/LocationService/LocationServiceProvider.swift
@@ -56,7 +56,6 @@ class LocationServiceProvider: NSObject, LocationServiceProviding {
 
 extension LocationServiceProvider: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        print("Did update location")
         if let currentLocation = locations.last {
             delegate?.locationRetrieved(location: currentLocation)
         }

--- a/GeofenceMe/LocationService/LocationServiceProvider.swift
+++ b/GeofenceMe/LocationService/LocationServiceProvider.swift
@@ -37,6 +37,21 @@ class LocationServiceProvider: NSObject, LocationServiceProviding {
     func getCurrentAuthorisationState() -> CLAuthorizationStatus {
         return locationManager.authorizationStatus
     }
+    
+    func startMonitoring(geofence: GeofenceInfo) {
+        let region = CLCircularRegion(center: CLLocationCoordinate2D(latitude: geofence.latitude, longitude: geofence.longitude),
+                                      radius: CLLocationDistance(geofence.radius),
+                                      identifier: "fence")
+        region.notifyOnEntry = true
+        locationManager.startMonitoring(for: region)
+    }
+    
+    func stopMonitoring(geofence: GeofenceInfo) {
+        let region = CLCircularRegion(center: CLLocationCoordinate2D(latitude: geofence.latitude, longitude: geofence.longitude),
+                                      radius: CLLocationDistance(geofence.radius),
+                                      identifier: "fence")
+        locationManager.stopMonitoring(for: region)
+    }
 }
 
 extension LocationServiceProvider: CLLocationManagerDelegate {

--- a/GeofenceMe/LocationService/LocationServiceProviding.swift
+++ b/GeofenceMe/LocationService/LocationServiceProviding.swift
@@ -14,5 +14,8 @@ protocol LocationServiceProviding {
     func startLocationDetection()
     func stopLocationDetection()
     
+    func startMonitoring(geofence: GeofenceInfo)
+    func stopMonitoring(geofence: GeofenceInfo)
+    
     var delegate: LocationServiceDelegate? { get set }
 }

--- a/GeofenceMe/NotificationService/NotificationService.swift
+++ b/GeofenceMe/NotificationService/NotificationService.swift
@@ -1,0 +1,41 @@
+//
+//  NotificationService.swift
+//  GeofenceMe
+//
+//  Created by Abd Sani Abd Jalal on 01/09/2021.
+//
+
+import Foundation
+import UserNotifications
+import UIKit
+
+class NotificationService {
+    func requestPermission() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { isAuthorised, error in
+            print(isAuthorised)
+            print(error)
+        }
+    }
+    
+    func clearNotifications() {
+        UIApplication.shared.applicationIconBadgeNumber = 0
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+    
+    func sendLocalNotification(text: String) {
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.body = text
+        notificationContent.sound = .default
+        notificationContent.badge = UIApplication.shared.applicationIconBadgeNumber + 1 as NSNumber
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: "location_change", content: notificationContent, trigger: trigger)
+        
+        UNUserNotificationCenter.current().add(request) { error in
+          if let error = error {
+            print("Error: \(error)")
+          }
+        }
+    }
+}

--- a/GeofenceMeTests/LocationServiceMock.swift
+++ b/GeofenceMeTests/LocationServiceMock.swift
@@ -10,6 +10,14 @@ import CoreLocation
 @testable import GeofenceMe
 
 class LocationServiceMock: LocationServiceProviding {
+    func startMonitoring(geofence: GeofenceInfo) {
+        
+    }
+    
+    func stopMonitoring(geofence: GeofenceInfo) {
+    
+    }
+    
     var isStartLocationDetectionCalled = false
     var isStopLocationDetectionCalled = false
     


### PR DESCRIPTION
This PR adds the notification service to the geofence monitor. Once a user exits or enters a geofenced region, the application will send a local notification to the user. Opening the local notification will do nothing but open the app.